### PR TITLE
Ensure blog listings show newest articles first

### DIFF
--- a/src/app/blog/[page]/page.tsx
+++ b/src/app/blog/[page]/page.tsx
@@ -25,12 +25,16 @@ export default async function BlogPage({ params }: BlogPageProps) {
   const apiParams = new DrupalJsonApiParams()
   apiParams.addSort("created", "DESC")
 
-  const allNodes = await drupal.getResourceCollectionFromContext<DrupalNode>(
-    "node--article",
-    {
-      params: apiParams.getQueryObject(),
-    }
+  const allNodes = (
+    await drupal.getResourceCollectionFromContext<DrupalNode>(
+      "node--article",
+      {
+        params: apiParams.getQueryObject(),
+      }
+    )
   )
+    .slice()
+    .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())
 
   const totalPosts = allNodes.length
   const totalPages = Math.ceil(totalPosts / POSTS_PER_PAGE)
@@ -65,12 +69,16 @@ export async function generateStaticParams() {
     const apiParams = new DrupalJsonApiParams()
     apiParams.addSort("created", "DESC")
 
-    const nodes = await drupal.getResourceCollectionFromContext<DrupalNode>(
-      "node--article",
-      {
-        params: apiParams.getQueryObject(),
-      }
+    const nodes = (
+      await drupal.getResourceCollectionFromContext<DrupalNode>(
+        "node--article",
+        {
+          params: apiParams.getQueryObject(),
+        }
+      )
     )
+      .slice()
+      .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())
 
     const totalPages = Math.ceil(nodes.length / POSTS_PER_PAGE)
     const pages = []

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,9 @@ export default async function HomePage() {
         params: apiParams.getQueryObject(),
       }
     )
-    allNodes = fetchedNodes as unknown as any[]
+    allNodes = (fetchedNodes as unknown as any[])
+      .slice()
+      .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())
   } catch (error) {
     console.error('Failed to fetch posts:', error)
   }


### PR DESCRIPTION
## Summary
- sort fetched articles by created date descending before slicing for display
- apply consistent sorting for homepage, paginated blog listings, and static path generation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692b53ef7a18832aaf33418995fc4f32)