### PR TITLE
Add article body classes to full blog view

### DIFF
--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -39,9 +39,12 @@ export default function BlogPostPage({ node, comments = [] }: BlogPostPageProps)
         <meta name="twitter:description" content={excerpt} />
       </Head>
 
-      <article className="max-w-4xl mx-auto px-4">
+      <article className="full max-w-4xl mx-auto px-4">
         <header className="mb-8">
-          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
+          <h1
+            id="page-title"
+            className="text-4xl md:text-5xl font-bold text-gray-900 mb-4"
+          >
             {node.title}
           </h1>
           <div className="flex items-center text-gray-600 text-sm space-x-4">
@@ -66,7 +69,7 @@ export default function BlogPostPage({ node, comments = [] }: BlogPostPageProps)
         </header>
 
         <div
-          className="blog-content prose prose-lg max-w-none"
+          className="article-body blog-content prose prose-lg max-w-none"
           dangerouslySetInnerHTML={{ __html: node.body?.value || "" }}
         />
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -114,8 +114,13 @@ pre[class*="language-"] {
 }
 
 /* Custom styles for blog content */
-.blog-content {
+.blog-content,
+.article-body {
   @apply prose prose-lg max-w-none;
+}
+
+.article-body p {
+  @apply mb-4;
 }
 
 .blog-content img {


### PR DESCRIPTION
## Summary
- add article-level and article-body classes to the full blog post view so tests can target its content
- share prose styling with the article-body container and ensure paragraphs keep spacing
- expose a predictable page title id for test selectors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692dc7d05a30832a9fa2d9fdd36f4173)