### PR TITLE
Normalize excerpts to remove non-breaking spaces

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,8 +22,13 @@ export function getNodePath(node: DrupalNode): string {
 }
 
 export function extractExcerpt(body: string, maxLength: number = 200): string {
+  const normalizedBody = body
+    // Replace HTML non-breaking spaces with regular spaces
+    .replace(/&nbsp;/gi, " ")
+    // Replace unicode non-breaking space characters
+    .replace(/\u00a0/g, " ")
   // Strip HTML tags
-  const text = body.replace(/<[^>]*>/g, "")
+  const text = normalizedBody.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim()
   // Truncate to maxLength
   if (text.length <= maxLength) return text
   return text.substring(0, maxLength).trim() + "..."


### PR DESCRIPTION
## Summary
- replace HTML and unicode non-breaking spaces with regular spaces when building excerpts
- collapse whitespace while generating excerpts to keep teasers tidy

## Testing
- npm run lint *(fails: `next` command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692dd59adcb8832abd978d706fc20bb5)