### PR TITLE
Fix tag term pages by resolving taxonomy IDs to UUIDs

### DIFF
--- a/src/lib/drupal.ts
+++ b/src/lib/drupal.ts
@@ -5,9 +5,12 @@ import { DrupalJsonApiParams } from "drupal-jsonapi-params"
 
 const DEFAULT_PAGE_SIZE = 50
 const PATH_UUID_MAP_FILE = path.join(process.cwd(), ".cache", "path-uuid-map.json")
+const TAG_UUID_MAP_FILE = path.join(process.cwd(), ".cache", "tag-uuid-map.json")
 
 type PathUuidMap = Record<string, string>
+type TagUuidMap = Record<string, string>
 let cachedPathUuidMap: PathUuidMap | null = null
+let cachedTagUuidMap: TagUuidMap | null = null
 
 const drupalConfig: any = {}
 
@@ -148,3 +151,55 @@ export function addNodesToPathUuidMap(nodes: DrupalNode[]) {
 }
 
 export { normalizePath }
+
+function buildTagUuidMap(tags: any[]): TagUuidMap {
+  const map: TagUuidMap = {}
+
+  tags.forEach((tag) => {
+    const tid = (tag?.drupal_internal__tid || tag?.tid)?.toString()
+
+    if (tid && tag?.id) {
+      map[tid] = tag.id
+    }
+  })
+
+  return map
+}
+
+async function loadTagUuidMapFromDisk(): Promise<TagUuidMap> {
+  if (cachedTagUuidMap) {
+    return cachedTagUuidMap
+  }
+
+  try {
+    const data = await fs.readFile(TAG_UUID_MAP_FILE, "utf8")
+    const map = (JSON.parse(data) as TagUuidMap) || {}
+    cachedTagUuidMap = map
+    return map
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") {
+      console.warn("[drupal] Failed to read tag UUID map:", error)
+    }
+    cachedTagUuidMap = {}
+    return cachedTagUuidMap
+  }
+}
+
+async function persistTagUuidMap(map: TagUuidMap) {
+  await fs.mkdir(path.dirname(TAG_UUID_MAP_FILE), { recursive: true })
+  await fs.writeFile(TAG_UUID_MAP_FILE, JSON.stringify(map, null, 2), "utf8")
+  cachedTagUuidMap = map
+}
+
+export async function ensureTagUuidMap(tags?: any[]): Promise<TagUuidMap> {
+  const existing = await loadTagUuidMapFromDisk()
+  if (Object.keys(existing).length) {
+    return existing
+  }
+
+  const sourceTags = tags || (await getAllResources<any>("taxonomy_term--tags"))
+  const map = buildTagUuidMap(sourceTags)
+  await persistTagUuidMap(map)
+
+  return map
+}

--- a/src/pages/tag/[tid].tsx
+++ b/src/pages/tag/[tid].tsx
@@ -1,6 +1,10 @@
 import { GetStaticPaths, GetStaticProps } from "next"
 import Head from "next/head"
-import { drupal, getAllResources } from "@/lib/drupal"
+import {
+  drupal,
+  ensureTagUuidMap,
+  getAllResources,
+} from "@/lib/drupal"
 import { DrupalNode } from "next-drupal"
 import BlogPostCard from "@/components/BlogPostCard"
 import { DrupalJsonApiParams } from "drupal-jsonapi-params"
@@ -53,6 +57,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
       {}
     )
 
+    await ensureTagUuidMap(terms)
+
     const paths = terms.map((term: any) => ({
       params: {
         tid: term.drupal_internal__tid?.toString() || term.id,
@@ -80,9 +86,12 @@ export const getStaticProps: GetStaticProps<TagPageProps> = async ({ params }) =
   try {
     console.log(`[getStaticProps] Fetching tag ${tid}...`)
 
+    const tagUuidMap = await ensureTagUuidMap()
+    const tagId = tagUuidMap[tid] || tid
+
     const term = await drupal.getResource(
       "taxonomy_term--tags",
-      tid
+      tagId
     )
 
     if (!term) {

--- a/src/pages/tag/[tid].tsx
+++ b/src/pages/tag/[tid].tsx
@@ -52,10 +52,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   try {
     console.log('[getStaticPaths] Fetching all tags...')
 
-    const terms = await drupal.getResourceCollection(
-      "taxonomy_term--tags",
-      {}
-    )
+    const terms = await getAllResources<any>("taxonomy_term--tags")
 
     await ensureTagUuidMap(terms)
 


### PR DESCRIPTION
## Summary
- add cached tag UUID map to resolve taxonomy terms by drupal_internal__tid
- ensure tag static paths persist the map and tag pages fetch terms via mapped UUIDs

## Testing
- npm test -- --runInBand *(fails: Missing script "test")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692dd67fe9f0832a937008e615e18530)