### PR TITLE
Add term list class to taxonomy tags

### DIFF
--- a/src/components/BlogPostCard.tsx
+++ b/src/components/BlogPostCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { DrupalNode } from "next-drupal"
 import { formatDate, getNodePath, extractExcerpt } from "@/lib/utils"
+import TagList from "./TagList"
 
 interface BlogPostCardProps {
   node: DrupalNode
@@ -32,19 +33,7 @@ export default function BlogPostCard({ node }: BlogPostCardProps) {
           </p>
         )}
 
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-4 px-4">
-            {tags.map((tag: any) => (
-              <Link
-                key={tag.id}
-                href={`/tag/${tag.drupal_internal__tid}/`}
-                className="tag"
-              >
-                {tag.name}
-              </Link>
-            ))}
-          </div>
-        )}
+        <TagList tags={tags} className="mb-4 px-4" />
 
         <Link
           href={path}

--- a/src/components/TagList.tsx
+++ b/src/components/TagList.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+
+interface TagListProps {
+  tags: any[]
+  className?: string
+}
+
+export default function TagList({ tags, className = "" }: TagListProps) {
+  if (!tags?.length) {
+    return null
+  }
+
+  return (
+    <div className={`field-type-taxonomy-term-reference ${className}`.trim()}>
+      <ul className="links field-items term-list flex flex-wrap gap-2 list-none p-0 m-0">
+        {tags.map((tag: any) => (
+          <li key={tag.id}>
+            <Link
+              href={`/tag/${tag.drupal_internal__tid}/`}
+              className="tag inline-block"
+            >
+              {tag.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -1,6 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from "next"
 import Head from "next/head"
-import Link from "next/link"
 import {
   addNodesToPathUuidMap,
   drupal,
@@ -12,6 +11,7 @@ import { DrupalNode } from "next-drupal"
 import { formatDate, absoluteUrl } from "@/lib/utils"
 import Comments from "@/components/Comments"
 import { DrupalJsonApiParams } from "drupal-jsonapi-params"
+import TagList from "@/components/TagList"
 
 interface BlogPostPageProps {
   node: DrupalNode
@@ -50,19 +50,7 @@ export default function BlogPostPage({ node, comments = [] }: BlogPostPageProps)
             </time>
           </div>
 
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-4">
-              {tags.map((tag: any) => (
-                <Link
-                  key={tag.id}
-                  href={`/tag/${tag.drupal_internal__tid}/`}
-                  className="tag"
-                >
-                  {tag.name}
-                </Link>
-              ))}
-            </div>
-          )}
+          <TagList tags={tags} className="mt-4" />
         </header>
 
         <div


### PR DESCRIPTION
## Summary
- add the `term-list` class to the shared TagList markup so the selector is available for tests

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692dd5c9dcec832abe8e914508e74ffb)