### PR TITLE
Ensure comment issue link is always rendered

### DIFF
--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -27,6 +27,21 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
   const repo = process.env.NEXT_PUBLIC_GITHUB_REPO || "eiriksm/eiriksm.dev-comments"
   const issueUrl = `https://github.com/${repo}/issues/${issueId}`
 
+  const commentCount = comments.length
+  const commentCountDisplay = `${commentCount}`.padStart(2, "0")
+  const commentWord =
+    commentCount === 1 ? "comment" : `comments${commentCount === 0 ? " 😿" : ""}`
+
+  const commentHeader = (
+    <div className="comment-header border-b-2 py-2 uppercase font-bold">
+      <span className="count bg-blue-800 text-white rounded text-lg p-1 font-mono">
+        {commentCountDisplay}
+      </span>
+      <span> </span>
+      {commentWord}
+    </div>
+  )
+
   useEffect(() => {
     if (initialComments.length > 0) {
       return
@@ -86,9 +101,9 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
 
   if (loading) {
     return (
-      <div className="mt-12 pt-8 border-t border-gray-200">
-        <h2 className="text-2xl font-bold mb-6">Comments</h2>
-        <div className="text-gray-500">Loading comments...</div>
+      <div className="comment-wrapper border-t-2 my-2 py-1 mt-12 pt-8 border-gray-200">
+        {commentHeader}
+        <div className="text-gray-500 mt-4">Loading comments...</div>
         {commentLink}
       </div>
     )
@@ -96,8 +111,8 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
 
   if (error) {
     return (
-      <div className="mt-12 pt-8 border-t border-gray-200">
-        <h2 className="text-2xl font-bold mb-6">Comments</h2>
+      <div className="comment-wrapper border-t-2 my-2 py-1 mt-12 pt-8 border-gray-200">
+        {commentHeader}
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
           <p className="text-gray-700 mb-4">
             Comments for this post are hosted on GitHub Issues.
@@ -117,10 +132,8 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
   }
 
   return (
-    <div className="mt-12 pt-8 border-t border-gray-200">
-      <h2 className="text-2xl font-bold mb-6">
-        Comments ({comments.length})
-      </h2>
+    <div className="comment-wrapper border-t-2 my-2 py-1 mt-12 pt-8 border-gray-200">
+      {commentHeader}
 
       {comments.length === 0 ? (
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -24,6 +24,8 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
   const [comments, setComments] = useState<Comment[]>(initialComments)
   const [loading, setLoading] = useState(initialComments.length === 0)
   const [error, setError] = useState<string | null>(null)
+  const repo = process.env.NEXT_PUBLIC_GITHUB_REPO || "eiriksm/eiriksm.dev-comments"
+  const issueUrl = `https://github.com/${repo}/issues/${issueId}`
 
   useEffect(() => {
     if (initialComments.length > 0) {
@@ -65,11 +67,29 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
     fetchComments()
   }, [issueId])
 
+  const commentLink = (
+    <div className="comment-link-wrapper mt-6">
+      <p>Do you want to comment?</p>
+      <p className="text-sm">
+        This article uses github for commenting. To comment, you can visit{" "}
+        <a
+          href={issueUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {issueUrl}
+        </a>
+        .
+      </p>
+    </div>
+  )
+
   if (loading) {
     return (
       <div className="mt-12 pt-8 border-t border-gray-200">
         <h2 className="text-2xl font-bold mb-6">Comments</h2>
         <div className="text-gray-500">Loading comments...</div>
+        {commentLink}
       </div>
     )
   }
@@ -83,7 +103,7 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
             Comments for this post are hosted on GitHub Issues.
           </p>
           <a
-            href={`https://github.com/${process.env.NEXT_PUBLIC_GITHUB_REPO}/issues/${issueId}`}
+            href={issueUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
@@ -91,6 +111,7 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
             View Comments on GitHub →
           </a>
         </div>
+        {commentLink}
       </div>
     )
   }
@@ -107,7 +128,7 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
             No comments yet. Be the first to comment on GitHub!
           </p>
           <a
-            href={`https://github.com/${process.env.NEXT_PUBLIC_GITHUB_REPO}/issues/${issueId}`}
+            href={issueUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
@@ -150,7 +171,7 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
 
           <div className="mt-6">
             <a
-              href={`https://github.com/${process.env.NEXT_PUBLIC_GITHUB_REPO}/issues/${issueId}`}
+              href={issueUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-block bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
@@ -160,6 +181,7 @@ export default function Comments({ issueId, initialComments = [] }: CommentsProp
           </div>
         </div>
       )}
+      {commentLink}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- ensure GitHub issue URL uses a consistent value and is shared across component states
- render the comment link wrapper in loading, error, and success views so the issue ID is always discoverable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ddf89e6fc832a8c494ebdc385a53f)