### PR TITLE
Hide header menu unless NEXT_PUBLIC_SHOW_MENU=1

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,8 @@ import Link from "next/link"
 import DarkModeToggle from "./DarkModeToggle"
 
 export default function Header() {
+  const showMenu = process.env.NEXT_PUBLIC_SHOW_MENU === "1"
+
   return (
     <header style={{ backgroundColor: 'var(--bg-secondary)', borderBottom: '1px solid var(--border-color)' }}>
       <div className="max-w-4xl mx-auto px-4 py-6">
@@ -14,37 +16,39 @@ export default function Header() {
             eiriksm.dev
           </Link>
           <div className="flex items-center gap-6">
-            <nav>
-              <ul className="flex space-x-6">
-                <li>
-                  <Link
-                    href="/"
-                    className="transition-colors"
-                    style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}
-                  >
-                    Blog
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/about"
-                    className="transition-colors"
-                    style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}
-                  >
-                    About
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    href="/talks"
-                    className="transition-colors"
-                    style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}
-                  >
-                    Talks
-                  </Link>
-                </li>
-              </ul>
-            </nav>
+            {showMenu ? (
+              <nav>
+                <ul className="flex space-x-6">
+                  <li>
+                    <Link
+                      href="/"
+                      className="transition-colors"
+                      style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}
+                    >
+                      Blog
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href="/about"
+                      className="transition-colors"
+                      style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}
+                    >
+                      About
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href="/talks"
+                      className="transition-colors"
+                      style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}
+                    >
+                      Talks
+                    </Link>
+                  </li>
+                </ul>
+              </nav>
+            ) : null}
             <DarkModeToggle />
           </div>
         </div>


### PR DESCRIPTION
### Motivation

- Make the header navigation opt-in via environment to allow hiding the site menu in deployments.
- Provide a simple feature flag driven by `NEXT_PUBLIC_SHOW_MENU` for runtime configuration.

### Description

- Add `const showMenu = process.env.NEXT_PUBLIC_SHOW_MENU === "1"` to `src/components/Header.tsx`.
- Wrap the existing navigation markup in a conditional render so the menu is only shown when `showMenu` is true.
- Preserve the `DarkModeToggle` and other header layout while keeping the navigation markup unchanged when enabled.
- This change updates a single file: `src/components/Header.tsx`.

### Testing

- No automated tests were run for this change.
- No CI or test results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946861b9a60832a97b8f2eca9dd1460)