### PR TITLE
Improve comment code contrast in dark mode

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,6 +14,10 @@
   --accent-hover: #0d9488;
   --link-color: #2563eb;
   --link-hover: #1d4ed8;
+  --comment-code-bg: #e5e7eb;
+  --comment-code-text: #111827;
+  --comment-pre-bg: #1f2937;
+  --comment-pre-text: #f9fafb;
   --tag-bg: #14b8a6;
   --tag-text: #ffffff;
   --header-bg: #f9fafb;
@@ -32,6 +36,10 @@ html.dark {
   --accent-hover: #2dd4bf;
   --link-color: #60a5fa;
   --link-hover: #93c5fd;
+  --comment-code-bg: #0f172a;
+  --comment-code-text: #e2e8f0;
+  --comment-pre-bg: #0b1220;
+  --comment-pre-text: #e2e8f0;
   --tag-bg: #14b8a6;
   --tag-text: #ffffff;
   --header-bg: #1f2937;
@@ -520,7 +528,8 @@ html.dark .article-body {
 }
 
 .comment-body code {
-  background-color: var(--bg-secondary);
+  background-color: var(--comment-code-bg);
+  color: var(--comment-code-text);
   padding: 0.15rem 0.4rem;
   border-radius: 4px;
   font-size: 0.875em;
@@ -528,7 +537,8 @@ html.dark .article-body {
 }
 
 .comment-body pre {
-  background-color: #272822;
+  background-color: var(--comment-pre-bg);
+  color: var(--comment-pre-text);
   padding: 1rem;
   border-radius: 6px;
   overflow-x: auto;


### PR DESCRIPTION
### Motivation
- Inline and block code inside comments were low-contrast in dark mode and hard to read.  
- The change introduces dedicated color tokens for comment code to improve legibility.  
- Keep comment code styling consistent between light and dark themes using CSS variables.  

### Description
- Added new CSS variables `--comment-code-bg`, `--comment-code-text`, `--comment-pre-bg`, and `--comment-pre-text` in `:root` and `html.dark`.  
- Updated `.comment-body code` to use `--comment-code-bg` and `--comment-code-text` for inline code.  
- Updated `.comment-body pre` to use `--comment-pre-bg` and `--comment-pre-text` for block code.  

### Testing
- Attempted to start the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` to visually verify styling, but the command failed because `next` was not available in the environment.  
- No other automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69469cb1f798832a89a08e7a93b70acf)