### PR TITLE
Improve inline code contrast in light and dark themes

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -86,10 +86,12 @@ pre[class*="language-"] {
 
 /* Inline code */
 :not(pre) > code[class*="language-"],
-:not(pre) > code {
+:not(pre) > code,
+.blog-content :not(pre) > code,
+.article-body :not(pre) > code {
   color: var(--inline-code-text);
   background: var(--inline-code-bg);
-  padding: 0.1em;
+  padding: 0.1em 0.25em;
   border-radius: 0.3em;
   white-space: normal;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,6 +18,8 @@
   --tag-text: #ffffff;
   --header-bg: #f9fafb;
   --footer-bg: #1f2937;
+  --inline-code-bg: #0b0b0b;
+  --inline-code-text: #ffffff;
 }
 
 html.dark {
@@ -36,6 +38,8 @@ html.dark {
   --tag-text: #ffffff;
   --header-bg: #1f2937;
   --footer-bg: #111827;
+  --inline-code-bg: #f9fafb;
+  --inline-code-text: #111827;
 }
 
 body {
@@ -81,7 +85,10 @@ pre[class*="language-"] {
 }
 
 /* Inline code */
-:not(pre) > code[class*="language-"] {
+:not(pre) > code[class*="language-"],
+:not(pre) > code {
+  color: var(--inline-code-text);
+  background: var(--inline-code-bg);
   padding: 0.1em;
   border-radius: 0.3em;
   white-space: normal;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -94,6 +94,10 @@ pre[class*="language-"] {
   white-space: normal;
 }
 
+:not(pre) > code[class*="language-"] .token {
+  color: inherit;
+}
+
 .token.comment,
 .token.prolog,
 .token.doctype,


### PR DESCRIPTION
### Motivation
- Inline code in comments and prose needed higher contrast so it remains legible in both light and dark modes.
- Use theme variables to make inline-code colors easy to adjust and consistent across the site.

### Description
- Added two CSS variables `--inline-code-bg` and `--inline-code-text` to `:root` and `html.dark` with inverted values for each theme.
- Applied those variables to inline code by updating the selector to `:not(pre) > code[class*="language-"], :not(pre) > code` and setting `color` and `background` accordingly in `src/styles/globals.css`.
- Kept existing block code (`pre[class*="language-"]`) styles unchanged to preserve Prism/Monokai appearance.

### Testing
- Attempted to run the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which failed because `next` was not installed and the server could not start.
- No automated unit or integration tests were executed as part of this change due to the unavailable dev environment.
- Verified the CSS patch applied cleanly and committed the change to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69469d4c56d0832ab57031f6f7dadd76)