### PR TITLE
Honor ISSUE_BASE when building GitHub issue/comment URLs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     services:
       chromedriver:
-        image: nymediaas/chrome-headless:89
+        image: nymediaas/chrome-headless
         ports:
           - 8643:8643
     strategy:
@@ -67,7 +67,7 @@ jobs:
         run: ./vendor/bin/wait-for-listen 9000
 
       - name: Debug
-        run: docker run --rm --entrypoint="" nymediaas/chrome-headless:89 ifconfig
+        run: docker run --rm --entrypoint="" nymediaas/chrome-headless ifconfig
 
       - name: Make a directory we need
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Make sure serving has started
         run: ./vendor/bin/wait-for-listen 9000
 
-      - name: Debug
-        run: docker run --rm --entrypoint="" nymediaas/chrome-headless:89 ifconfig
-
       - name: Make a directory we need
         run: mkdir -p public/ci_issues
 
@@ -77,7 +74,7 @@ jobs:
       - name: Stop the site serving and display pm2 logs
         if: always()
         run: |
-          pm2 logs server --lines 10000
+          pm2 logs server --nostream --lines 10000
           pm2 delete server
 
       - uses: actions/upload-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,18 +67,8 @@ jobs:
       - name: Make sure serving has started
         run: ./vendor/bin/wait-for-listen 9000
 
-      - name: Debug
-        run: docker run --rm --entrypoint="" nymediaas/chrome-headless ifconfig
-
       - name: Make a directory we need
-        run: |
-          mkdir -p out/ci_issues
-          # And test one file?
-          mkdir -p out/ci_issues/666
-          echo "test" > out/ci_issues/666/comments
-          curl http://172.17.0.1:9000/ci_issues/666/comments
-          curl localhost:9000/ci_issues/666/comments
-
+        run: mkdir -p out/ci_issues
 
       - name: Run tests
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,18 @@ jobs:
       - name: Make sure serving has started
         run: ./vendor/bin/wait-for-listen 9000
 
+      - name: Debug
+        run: docker run --rm --entrypoint="" nymediaas/chrome-headless:89 ifconfig
+
       - name: Make a directory we need
-        run: mkdir -p out/ci_issues
+        run: |
+          mkdir -p out/ci_issues
+          # And test one file?
+          mkdir -p out/ci_issues/666
+          echo "test" > out/ci_issues/666/comments
+          curl http://172.17.0.1:9000/ci_issues/666/comments
+          curl localhost:9000/ci_issues/666/comments
+
 
       - name: Run tests
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
       API_URL: ${{ secrets.API_URL }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NEXT_PUBLIC_GITHUB_REPO: eiriksm/eiriksm.dev-comments
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,10 @@ jobs:
         run: wget ${{ secrets.DISQUS_XML_URL }} -O disqus.xml
 
       - name: Install node dependencies
-        run: npm i
+        run:  |
+          npm i
+          # Also install pm2 globally.
+          npm install -g pm2
 
       - name: Build the site
         run: npm run build
@@ -57,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start the serving of the site
-        run: npx --yes serve@latest -l tcp://0.0.0.0:9000 out &
+        run: pm2 start "npx --yes serve@latest -l tcp://0.0.0.0:9000 out" --name server
 
       - name: Make sure serving has started
         run: ./vendor/bin/wait-for-listen 9000
@@ -70,3 +73,8 @@ jobs:
 
       - name: Run tests
         run: composer test
+
+      - name: Stop the site serving and display pm2 logs
+        run: |
+          pm2 logs server --lines 10000
+          pm2 delete server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.4"
+          php-version: "8.3"
 
       - name: Use Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         run: ./vendor/bin/wait-for-listen 9000
 
       - name: Make a directory we need
-        run: mkdir -p public/ci_issues
+        run: mkdir -p out/ci_issues
 
       - name: Run tests
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,14 @@ jobs:
           - 8643:8643
     strategy:
       fail-fast: false
+    env:
+      NEXT_PUBLIC_DRUPAL_BASE_URL:  ${{ secrets.API_URL }}
+      ISSUE_BASE: http://172.17.0.1:9000/ci_issues/
+      NEXT_PUBLIC_ISSUE_BASE: http://172.17.0.1:9000/ci_issues/
+      BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
+      BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
+      API_URL: ${{ secrets.API_URL }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,14 +59,6 @@ jobs:
 
       - name: Build the site
         run: npm run build
-        env:
-          NEXT_PUBLIC_DRUPAL_BASE_URL:  ${{ secrets.API_URL }}
-          ISSUE_BASE: http://172.17.0.1:9000/ci_issues/
-          NEXT_PUBLIC_ISSUE_BASE: http://172.17.0.1:9000/ci_issues/
-          BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
-          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
-          API_URL: ${{ secrets.API_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start the serving of the site
         run: pm2 start "npx --yes serve@latest -l tcp://0.0.0.0:9000 out" --name server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           NEXT_PUBLIC_DRUPAL_BASE_URL:  ${{ secrets.API_URL }}
           ISSUE_BASE: http://172.17.0.1:9000/ci_issues/
+          NEXT_PUBLIC_ISSUE_BASE: http://172.17.0.1:9000/ci_issues/
           BASIC_AUTH_USERNAME: ${{ secrets.BASIC_AUTH_USERNAME }}
           BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD }}
           API_URL: ${{ secrets.API_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
         run: composer test
 
       - name: Stop the site serving and display pm2 logs
+        if: always()
         run: |
           pm2 logs server --lines 10000
           pm2 delete server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     services:
       chromedriver:
-        image: nymediaas/chrome-headless
+        image: ghcr.io/nymedia/chrome-headless:with-chromedriver
         ports:
           - 8643:8643
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,10 @@ jobs:
         run: |
           pm2 logs server --lines 10000
           pm2 delete server
+
+      - uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: screenshots
+          path: screenshots
+          if-no-files-found: ignore

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -15,10 +15,17 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
   extensions:
+    frontkom\BehatAutoDdevNonHeadless\DisableHeadlessExtension: ~
+    DrevOps\BehatScreenshotExtension:
+      dir: '%paths.base%/screenshots'
+      fail: true
+      fail_prefix: 'failed_'
+      purge: false
     Behat\MinkExtension:
       files_path: '%paths.base%/tests/files'
       base_url: http://172.17.0.1:9000
       goutte: ~
+      browser_name: chrome
       selenium2:
         wd_host: http://127.0.0.1:8643/wd/hub
         capabilities:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -19,7 +19,7 @@ default:
     DrevOps\BehatScreenshotExtension:
       dir: '%paths.base%/screenshots'
       fail: true
-      fail_prefix: 'failed_'
+      failed_prefix: 'failed_'
       purge: false
     Behat\MinkExtension:
       files_path: '%paths.base%/tests/files'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -8,6 +8,7 @@ default:
       filters:
         tags: "~@todo"
       contexts:
+        - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
         - eiriksm\Orkjern\Tests\Context\FeatureContext
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MinkContext
@@ -18,7 +19,7 @@ default:
     frontkom\BehatAutoDdevNonHeadless\DisableHeadlessExtension: ~
     DrevOps\BehatScreenshotExtension:
       dir: '%paths.base%/screenshots'
-      fail: true
+      on_failed: true
       failed_prefix: 'failed_'
       purge: false
     Behat\MinkExtension:

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
     },
     "require-dev": {
         "drupal/drupal-extension": "^4.0",
-        "eiriksm/wait-for-listen": "^1.0"
+        "eiriksm/wait-for-listen": "^1.0",
+        "frontkom/behat-ddev-auto-non-headless": "dev-main",
+        "drevops/behat-screenshot": "^2.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74e352db37778820ebf3da7d1d7724c7",
+    "content-hash": "ecfc5a8e400ce90438abd0e752a566ec",
     "packages": [],
     "packages-dev": [
         {
@@ -465,6 +465,83 @@
             "time": "2022-03-30T09:27:43+00:00"
         },
         {
+            "name": "drevops/behat-screenshot",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drevops/behat-screenshot.git",
+                "reference": "a4624f21b70b9723c9f74da4c7230265e99b0b03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drevops/behat-screenshot/zipball/a4624f21b70b9723c9f74da4c7230265e99b0b03",
+                "reference": "a4624f21b70b9723c9f74da4c7230265e99b0b03",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.13.0",
+                "friends-of-behat/mink-extension": "^2.7",
+                "php": ">=8.2",
+                "symfony/finder": "^6.4 || ^7.0",
+                "symfony/http-client": "^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8",
+                "behat/mink-browserkit-driver": "^2.2",
+                "dantleech/gherkin-lint": "^0.2.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1",
+                "dmore/behat-chrome-extension": "^1.4",
+                "drevops/behat-phpserver": "^2.0",
+                "drupal/coder": "^8.3",
+                "dvdoug/behat-code-coverage": "^5.3",
+                "ergebnis/composer-normalize": "^2.44",
+                "escapestudios/symfony2-coding-standard": "^3",
+                "lullabot/mink-selenium2-driver": "^1.7",
+                "lullabot/php-webdriver": "^2.0.4",
+                "mikey179/vfsstream": "^1.6",
+                "opis/closure": "^4.0",
+                "php-mock/php-mock-phpunit": "^2.13",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^11",
+                "rector/rector": "^2",
+                "symfony/process": "^6.4 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DrevOps\\BehatScreenshotExtension\\": "src/DrevOps/BehatScreenshotExtension"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Skrypnyk",
+                    "email": "alex@drevops.com",
+                    "homepage": "https://drevops.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Behat extension and step definitions to create HTML and image screenshots on demand or when tests fail",
+            "support": {
+                "issues": "https://github.com/drevops/behat-screenshot/issues",
+                "source": "https://github.com/drevops/behat-screenshot/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/drevops",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/drevops",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-06T06:26:31+00:00"
+        },
+        {
             "name": "drupal/core-utility",
             "version": "9.5.11",
             "source": {
@@ -853,6 +930,47 @@
                 "source": "https://github.com/FriendsOfBehat/MinkExtension/tree/v2.7.5"
             },
             "time": "2024-01-11T09:12:02+00:00"
+        },
+        {
+            "name": "frontkom/behat-ddev-auto-non-headless",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/frontkom/behat-ddev-auto-non-headless.git",
+                "reference": "387990ac856ace505fcac8ed365d87d35059427f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/frontkom/behat-ddev-auto-non-headless/zipball/387990ac856ace505fcac8ed365d87d35059427f",
+                "reference": "387990ac856ace505fcac8ed365d87d35059427f",
+                "shasum": ""
+            },
+            "require-dev": {
+                "behat/behat": "^3.14"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "frontkom\\BehatAutoDdevNonHeadless\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eirik S. Morland",
+                    "email": "eirik@morland.no"
+                }
+            ],
+            "description": "Automatically disables headless when running behat tests in ddev.",
+            "support": {
+                "issues": "https://github.com/frontkom/behat-ddev-auto-non-headless/issues",
+                "source": "https://github.com/frontkom/behat-ddev-auto-non-headless/tree/main"
+            },
+            "time": "2024-11-25T10:49:36+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1366,6 +1484,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
             "time": "2023-04-04T09:50:52+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
+            },
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -2185,6 +2353,253 @@
             "time": "2024-06-28T09:36:24+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v7.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/340b9ed7320570f319028a2cbec46d40535e94bd",
+                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-05T05:42:40+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v7.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "26cc224ea7103dda90e9694d9e139a389092d007"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/26cc224ea7103dda90e9694d9e139a389092d007",
+                "reference": "26cc224ea7103dda90e9694d9e139a389092d007",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-04T21:12:57+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-29T11:18:49+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.30.0",
             "source": {
@@ -2892,6 +3307,86 @@
             "time": "2024-06-19T12:30:46+00:00"
         },
         {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-08T02:45:35+00:00"
+        },
+        {
             "name": "symfony/process",
             "version": "v4.4.44",
             "source": {
@@ -3367,10 +3862,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "frontkom/behat-ddev-auto-non-headless": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo } from "react"
 import { formatDate } from "@/lib/utils"
 import type { DisqusComment } from "@/lib/disqus"
 import { parseCommentBody } from "@/lib/comment-parser"
+import { getIssueCommentsUrl } from "@/lib/github"
 
 interface GitHubComment {
   id: number
@@ -104,7 +105,7 @@ export default function Comments({ issueId, initialComments = [], disqusComments
 
       try {
         const response = await fetch(
-          `https://api.github.com/repos/${repo}/issues/${issueId}/comments`,
+          getIssueCommentsUrl(issueId, repo),
           {
             headers: process.env.GITHUB_TOKEN
               ? { Authorization: `token ${process.env.GITHUB_TOKEN}` }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,13 @@
+export function getIssueBase(repo: string): string {
+  const issueBase = process.env.ISSUE_BASE || process.env.NEXT_PUBLIC_ISSUE_BASE
+  const trimmedBase = issueBase?.replace(/\/$/, "")
+  return trimmedBase || `https://api.github.com/repos/${repo}/issues`
+}
+
+export function getIssueUrl(issueId: string, repo: string): string {
+  return `${getIssueBase(repo)}/${issueId}`
+}
+
+export function getIssueCommentsUrl(issueId: string, repo: string): string {
+  return `${getIssueBase(repo)}/${issueId}/comments`
+}

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -16,6 +16,7 @@ import { DrupalJsonApiParams } from "drupal-jsonapi-params"
 import Link from "next/link"
 import { FaComment } from "react-icons/fa"
 import { getDisqusComments, type DisqusComment } from "@/lib/disqus"
+import { getIssueCommentsUrl } from "@/lib/github"
 
 interface BlogPostPageProps {
   node: DrupalNode
@@ -315,7 +316,7 @@ export const getStaticProps: GetStaticProps<BlogPostPageProps> = async ({ params
     if (node.field_issue_comment_id) {
       try {
         const response = await fetch(
-          `https://api.github.com/repos/${repo}/issues/${node.field_issue_comment_id}/comments`,
+          getIssueCommentsUrl(node.field_issue_comment_id, repo),
           {
             headers: process.env.GITHUB_TOKEN
               ? { Authorization: `token ${process.env.GITHUB_TOKEN}` }

--- a/src/pages/blog/[page].tsx
+++ b/src/pages/blog/[page].tsx
@@ -7,6 +7,7 @@ import Pagination from "@/components/Pagination"
 import { DrupalJsonApiParams } from "drupal-jsonapi-params"
 import { getDisqusCommentCount } from "@/lib/disqus"
 import { getNodePath } from "@/lib/utils"
+import { getIssueUrl } from "@/lib/github"
 
 const POSTS_PER_PAGE = 10
 
@@ -24,7 +25,7 @@ interface BlogPageProps {
 async function fetchCommentCount(issueId: string, repo: string): Promise<number> {
   try {
     const response = await fetch(
-      `https://api.github.com/repos/${repo}/issues/${issueId}`,
+      getIssueUrl(issueId, repo),
       {
         headers: process.env.GITHUB_TOKEN
           ? { Authorization: `token ${process.env.GITHUB_TOKEN}` }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import { DrupalJsonApiParams } from "drupal-jsonapi-params"
 import { generatePlanetFeed } from "@/lib/planet-feed"
 import { getDisqusCommentCount } from "@/lib/disqus"
 import { getNodePath } from "@/lib/utils"
+import { getIssueUrl } from "@/lib/github"
 
 const POSTS_PER_PAGE = 10
 
@@ -24,7 +25,7 @@ interface HomePageProps {
 async function fetchCommentCount(issueId: string, repo: string): Promise<number> {
   try {
     const response = await fetch(
-      `https://api.github.com/repos/${repo}/issues/${issueId}`,
+      getIssueUrl(issueId, repo),
       {
         headers: process.env.GITHUB_TOKEN
           ? { Authorization: `token ${process.env.GITHUB_TOKEN}` }

--- a/tests/src/Context/FeatureContext.php
+++ b/tests/src/Context/FeatureContext.php
@@ -148,7 +148,7 @@ class FeatureContext extends RawDrupalContext {
    * @Then /^I create an empty comment file in the last issue$/
    */
   public function iCreateAnEmptyCommentFileInTheLastIssue() {
-    $dir = __DIR__ . '/../../../public/ci_issues/' . $this->lastIssueId;
+    $dir = __DIR__ . '/../../../out/ci_issues/' . $this->lastIssueId;
     @mkdir($dir);
     file_put_contents($dir . '/comments', '[]');
   }
@@ -164,7 +164,7 @@ class FeatureContext extends RawDrupalContext {
    * @Then /^I place a comment in the last issue$/
    */
   public function iPlaceACommentInTheLastIssue() {
-    $dir = __DIR__ . '/../../../public/ci_issues/' . $this->lastIssueId;
+    $dir = __DIR__ . '/../../../out/ci_issues/' . $this->lastIssueId;
     @mkdir($dir);
     file_put_contents($dir . '/comments', '[
   {

--- a/tests/src/Context/FeatureContext.php
+++ b/tests/src/Context/FeatureContext.php
@@ -128,6 +128,18 @@ class FeatureContext extends RawDrupalContext {
    */
   public function iFindTheIssueIDForTheArticle() {
     $element = $this->getSession()->getPage()->find('css', '.comment-link-wrapper a');
+    $waited = 0;
+    while (!$element) {
+        $element = $this->getSession()->getPage()->find('css', '.comment-link-wrapper a');
+        if ($element) {
+            break;
+        }
+        $waited++;
+        if ($waited > 10) {
+            throw new \Exception('Could not find the issue link in the article within 10 seconds');
+        }
+        sleep(1);
+    }
     $href = $element->getAttribute('href');
     $this->lastIssueId = str_replace('https://github.com/eiriksm/eiriksm.dev-comments/issues/', '', $href);
   }
@@ -139,11 +151,6 @@ class FeatureContext extends RawDrupalContext {
     $dir = __DIR__ . '/../../../public/ci_issues/' . $this->lastIssueId;
     @mkdir($dir);
     file_put_contents($dir . '/comments', '[]');
-    $this->cacheBust();
-  }
-
-  protected function cacheBust() {
-
   }
 
   /**
@@ -173,7 +180,6 @@ class FeatureContext extends RawDrupalContext {
   }
 ]
 ');
-    $this->cacheBust();
   }
 
 }


### PR DESCRIPTION
### Motivation
- Keep parity with `master` by allowing `ISSUE_BASE` to override the base GitHub API URL used for comment and issue fetches.
- Make comment fetching configurable so the site can use an alternate API host (enterprise/proxy) via `ISSUE_BASE` or `NEXT_PUBLIC_ISSUE_BASE`.
- Centralize URL construction for GitHub issue endpoints to avoid duplicated hardcoded strings.

### Description
- Add `src/lib/github.ts` which provides `getIssueBase`, `getIssueUrl`, and `getIssueCommentsUrl` that honor `ISSUE_BASE` and `NEXT_PUBLIC_ISSUE_BASE` and trim trailing slashes.
- Replace hardcoded `https://api.github.com/repos/.../issues/...` strings with `getIssueCommentsUrl` and `getIssueUrl` in `src/components/Comments.tsx`, `src/pages/[...slug].tsx`, `src/pages/blog/[page].tsx`, and `src/pages/index.tsx`.
- Update imports in the modified files to use the new helpers and keep the rest of the fetch logic and headers unchanged.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6948e2ed2a5c832aad3e8e70b7564fc5)