### PR TITLE
Fix comment code readability and horizontal scrolling

### DIFF
--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -216,7 +216,7 @@ export default function Comments({ issueId, initialComments = [], disqusComments
                   alt={comment.author}
                   className="w-10 h-10 rounded-full"
                 />
-                <div className="flex-1">
+                <div className="flex-1 min-w-0">
                   <div className="flex flex-wrap items-center gap-2 mb-2">
                     {comment.authorUrl ? (
                       <a
@@ -241,7 +241,7 @@ export default function Comments({ issueId, initialComments = [], disqusComments
                     )}
                   </div>
                   <div
-                    className="comment-body prose prose-sm max-w-full min-w-0"
+                    className="comment-body prose prose-sm w-full max-w-full min-w-0"
                     style={{ color: 'var(--text-secondary)' }}
                     dangerouslySetInnerHTML={{ __html: parseCommentBody(comment.body) }}
                   />

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -241,7 +241,7 @@ export default function Comments({ issueId, initialComments = [], disqusComments
                     )}
                   </div>
                   <div
-                    className="comment-body prose prose-sm max-w-none"
+                    className="comment-body prose prose-sm max-w-full min-w-0"
                     style={{ color: 'var(--text-secondary)' }}
                     dangerouslySetInnerHTML={{ __html: parseCommentBody(comment.body) }}
                   />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -239,16 +239,9 @@ html.dark .article-body {
 }
 
 /* Comment styles */
-.comment-wrapper {
-  overflow-x: hidden;
-  max-width: 100%;
-}
-
 .comment {
   @apply mb-6 p-4 rounded-lg;
   background-color: var(--bg-secondary);
-  min-width: 0;
-  max-width: 100%;
 }
 
 .comment-author {
@@ -264,9 +257,6 @@ html.dark .article-body {
 .comment-body {
   @apply mt-2;
   color: var(--text-secondary);
-  min-width: 0;
-  max-width: 100% !important;
-  overflow-wrap: break-word;
 }
 
 /* Tag styles - rectangular, not rounded */
@@ -564,9 +554,7 @@ html.dark .article-body {
   color: var(--comment-pre-text);
   padding: 1rem;
   border-radius: 6px;
-  overflow-x: auto;
-  width: 100%;
-  box-sizing: border-box;
+  @apply overflow-x-auto max-w-full;
 }
 
 .comment-body pre code {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -242,6 +242,7 @@ html.dark .article-body {
 .comment {
   @apply mb-6 p-4 rounded-lg;
   background-color: var(--bg-secondary);
+  min-width: 0;
 }
 
 .comment-author {
@@ -257,8 +258,7 @@ html.dark .article-body {
 .comment-body {
   @apply mt-2;
   color: var(--text-secondary);
-  overflow-x: auto;
-  max-width: 100%;
+  min-width: 0;
 }
 
 /* Tag styles - rectangular, not rounded */
@@ -557,7 +557,8 @@ html.dark .article-body {
   padding: 1rem;
   border-radius: 6px;
   overflow-x: auto;
-  max-width: 100%;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .comment-body pre code {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -554,7 +554,7 @@ html.dark .article-body {
   color: var(--comment-pre-text);
   padding: 1rem;
   border-radius: 6px;
-  @apply overflow-x-auto max-w-full;
+  @apply overflow-x-auto w-full;
 }
 
 .comment-body pre code {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,8 +14,8 @@
   --accent-hover: #0d9488;
   --link-color: #2563eb;
   --link-hover: #1d4ed8;
-  --comment-code-bg: #e5e7eb;
-  --comment-code-text: #111827;
+  --comment-code-bg: #1f2937;
+  --comment-code-text: #f9fafb;
   --comment-pre-bg: #1f2937;
   --comment-pre-text: #f9fafb;
   --tag-bg: #14b8a6;
@@ -242,6 +242,7 @@ html.dark .article-body {
 .comment {
   @apply mb-6 p-4 rounded-lg;
   background-color: var(--bg-secondary);
+  overflow-x: hidden;
 }
 
 .comment-author {
@@ -257,6 +258,8 @@ html.dark .article-body {
 .comment-body {
   @apply mt-2;
   color: var(--text-secondary);
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 /* Tag styles - rectangular, not rounded */
@@ -555,6 +558,7 @@ html.dark .article-body {
   padding: 1rem;
   border-radius: 6px;
   overflow-x: auto;
+  max-width: 100%;
 }
 
 .comment-body pre code {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -239,10 +239,16 @@ html.dark .article-body {
 }
 
 /* Comment styles */
+.comment-wrapper {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
 .comment {
   @apply mb-6 p-4 rounded-lg;
   background-color: var(--bg-secondary);
   min-width: 0;
+  max-width: 100%;
 }
 
 .comment-author {
@@ -259,6 +265,8 @@ html.dark .article-body {
   @apply mt-2;
   color: var(--text-secondary);
   min-width: 0;
+  max-width: 100% !important;
+  overflow-wrap: break-word;
 }
 
 /* Tag styles - rectangular, not rounded */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -242,7 +242,6 @@ html.dark .article-body {
 .comment {
   @apply mb-6 p-4 rounded-lg;
   background-color: var(--bg-secondary);
-  overflow-x: hidden;
 }
 
 .comment-author {


### PR DESCRIPTION
- Improve inline code contrast in light mode by using dark background (#1f2937) with light text (#f9fafb)
- Fix horizontal page scrolling caused by code blocks in comments
- Add overflow handling to comment containers to scroll within their bounds
- Add max-width constraints to prevent code blocks from expanding beyond viewport