### PR TITLE
Make pagination symmetrical: align prev/next to edges and center indicator

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -15,27 +15,34 @@ export default function Pagination({ currentPage, totalPages, basePath = "/blog"
   }
 
   return (
-    <nav className="flex justify-center items-center space-x-4 mt-12" aria-label="Pagination">
-      {currentPage > 1 && (
+    <nav
+      className="mt-12 grid w-full grid-cols-[1fr_auto_1fr] items-center gap-4"
+      aria-label="Pagination"
+    >
+      {currentPage > 1 ? (
         <Link
           href={getPagePath(currentPage - 1)}
-          className="px-4 py-2 text-[var(--link-color)] hover:text-[var(--link-hover)] transition-colors"
+          className="justify-self-start px-2 py-1 text-[var(--link-color)] hover:text-[var(--link-hover)] transition-colors"
         >
           ← Previous
         </Link>
+      ) : (
+        <span className="px-2 py-1" aria-hidden="true" />
       )}
 
-      <span className="text-[var(--text-secondary)]">
+      <span className="text-center text-[var(--text-secondary)]">
         Page {currentPage} of {totalPages}
       </span>
 
-      {currentPage < totalPages && (
+      {currentPage < totalPages ? (
         <Link
           href={getPagePath(currentPage + 1)}
-          className="px-4 py-2 text-[var(--link-color)] hover:text-[var(--link-hover)] transition-colors"
+          className="justify-self-end px-2 py-1 text-[var(--link-color)] hover:text-[var(--link-hover)] transition-colors"
         >
           Next →
         </Link>
+      ) : (
+        <span className="px-2 py-1" aria-hidden="true" />
       )}
     </nav>
   )


### PR DESCRIPTION
### Motivation
- Make the pagination control visually symmetrical so previous/next links sit flush at the left and right edges.
- Keep the page indicator centered and preserve layout when either side is missing.
- Reduce padding and use styles that better match surrounding page typography and link sizing.

### Description
- Replaced the centered flex layout with a three-column grid using `grid w-full grid-cols-[1fr_auto_1fr]` in `src/components/Pagination.tsx`.
- Aligned links with `justify-self-start` and `justify-self-end`, reduced padding to `px-2 py-1`, and kept color/hover variables intact.
- Added placeholder `<span>` elements when previous or next links are absent to preserve symmetric spacing.
- Centered the page indicator with `text-center` while leaving `getPagePath` and overall component logic unchanged.

### Testing
- Started the dev server with `npm run dev` to verify compilation, which succeeded but page rendering returned 404 due to an unavailable external Drupal JSON:API endpoint. 
- Ran a Playwright script to capture a screenshot of `/blog/2/`, but the page could not be rendered because of the missing API and visual verification was not possible.
- No unit tests (`npm test` / `vitest`) were executed as part of this change.
- The change was lint/compiled during development and the updated file was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956cc849b84832ab79eed1b6ee2508c)